### PR TITLE
fix(devserver): use the devserver config directly rather than copying to bin

### DIFF
--- a/webpack/private/devserver/BUILD.bazel
+++ b/webpack/private/devserver/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files([
@@ -10,10 +9,4 @@ bzl_library(
     srcs = ["devserver.bzl"],
     visibility = ["//webpack:__subpackages__"],
     deps = ["@aspect_rules_js//js:defs"],
-)
-
-copy_to_bin(
-    name = "webpack.config",
-    srcs = ["webpack.config.js"],
-    visibility = ["//webpack:__subpackages__"],
 )

--- a/webpack/private/devserver/devserver.bzl
+++ b/webpack/private/devserver/devserver.bzl
@@ -22,7 +22,7 @@ See https://webpack.js.org/configuration/""",
     "_webpack_devserver_config": attr.label(
         doc = "Internal use only",
         allow_single_file = [".js"], 
-        default = Label("//webpack/private/devserver:webpack.config")
+        default = Label("//webpack/private/devserver:webpack.config.js")
     ),
 })
 


### PR DESCRIPTION
Referencing the `copy_to_bin` rule results in visibility errors, and when they are resolved it errors due to `copy_to_bin` not allowing copying files from outside of the source tree. We can just reference the file directly as it ends up in the right place in the runfiles tree.