### PR TITLE
fix(devserver): jest -> webpack naming

### DIFF
--- a/webpack/private/devserver/devserver.bzl
+++ b/webpack/private/devserver/devserver.bzl
@@ -48,8 +48,8 @@ def _impl(ctx):
 
     launcher = js_binary_lib.create_launcher(
         ctx,
-        log_prefix_rule_set = "aspect_rules_jest",
-        log_prefix_rule = "jest_test",
+        log_prefix_rule_set = "aspect_rules_webpack",
+        log_prefix_rule = "webpack_devserver",
         fixed_args = fixed_args,
     )
 


### PR DESCRIPTION
Fix the copy pasta from rules_jest? I don't know what this should be as the docs don't give any description of what these attributes are, https://github.com/aspect-build/rules_js/blob/main/docs/js_binary.md#js_binary_libcreate_launcher