### PR TITLE
fix: use name param passed to webpack_devserver macro

### DIFF
--- a/webpack/private/webpack_devserver.bzl
+++ b/webpack/private/webpack_devserver.bzl
@@ -47,7 +47,7 @@ def webpack_devserver(
         unwind_chdir_prefix = "/".join([".."] * len(chdir.split("/"))) + "/"
 
     js_run_devserver(
-        name = "devserver",
+        name = name,
         tool = webpack,
         args = [
             "serve",


### PR DESCRIPTION
Fixes https://github.com/aspect-build/rules_webpack/issues/65