### PR TITLE
feat: import toolchains to use for copy actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,12 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # TODO(alex): add testing on Bazel 7
       - id: bazel_6
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
-      - id: bazel_5
-        run: echo "bazelversion=5.3.2" >> $GITHUB_OUTPUT
     outputs:
-      # Will look like ["<version from .bazelversion>", "5.3.2"]
+      # Will look like ["<version from .bazelversion>", ...]
       bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
 
   matrix-prep-os:
@@ -72,13 +71,6 @@ jobs:
           - 'e2e/smoke'
           - 'e2e/worker'
         exclude:
-          # Don't test macos with Bazel 5 to minimize macOS minutes (billed at 10X)
-          # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
-          - os: macos-latest
-            bazelversion: 5.3.2
-          # Don't test bzlmod with Bazel 5 (not supported)
-          - bazelversion: 5.3.2
-            bzlmodEnabled: true
           # TODO
           - folder: e2e/loaders
             bzlmodEnabled: true

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -24,4 +24,12 @@ http_archive(
 EOF
 
 awk 'f;/--SNIP--/{f=1}' e2e/smoke/WORKSPACE.bazel
-echo "\`\`\`" 
+echo "\`\`\`"
+
+cat << EOF
+To use rules_webpack with bazel-lib 2.0, you must additionally register the coreutils toolchain.
+\`\`\`starlark
+load("@aspect_bazel_lib//lib:repositories.bzl", "register_coreutils_toolchains")
+register_coreutils_toolchains()
+\`\`\`
+EOF

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,8 +6,8 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.32.0")
-bazel_dep(name = "aspect_rules_js", version = "1.29.2")
+bazel_dep(name = "aspect_bazel_lib", version = "1.38.1")
+bazel_dep(name = "aspect_rules_js", version = "1.34.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 
 bazel_dep(name = "gazelle", version = "0.29.0", dev_dependency = True, repo_name = "bazel_gazelle")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,9 +17,11 @@ load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
 
 rules_js_dependencies()
 
-load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "register_coreutils_toolchains")
 
-aspect_bazel_lib_dependencies(override_local_config_platform = True)
+aspect_bazel_lib_dependencies()
+
+register_coreutils_toolchains()
 
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
 

--- a/e2e/loaders/WORKSPACE
+++ b/e2e/loaders/WORKSPACE
@@ -10,6 +10,10 @@ load("@aspect_rules_webpack//webpack:dependencies.bzl", "rules_webpack_dependenc
 
 rules_webpack_dependencies()
 
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
 # Fetch and register a nodejs interpreter, if you haven't already
 
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -16,6 +16,10 @@ load("@aspect_rules_webpack//webpack:dependencies.bzl", "rules_webpack_dependenc
 
 rules_webpack_dependencies()
 
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
 # Fetch and register a nodejs interpreter, if you haven't already
 
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")

--- a/e2e/worker/WORKSPACE
+++ b/e2e/worker/WORKSPACE
@@ -10,6 +10,10 @@ load("@aspect_rules_webpack//webpack:dependencies.bzl", "rules_webpack_dependenc
 
 rules_webpack_dependencies()
 
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
 # Fetch and register a nodejs interpreter, if you haven't already
 
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -9,6 +9,15 @@ load("//webpack/private:maybe.bzl", http_archive = "maybe_http_archive")
 
 def rules_webpack_internal_deps():
     "Fetch repositories used for developing the rules"
+
+    # opt-in to 2.0 without forcing users to do so
+    http_archive(
+        name = "aspect_bazel_lib",
+        sha256 = "c858cc637db5370f6fd752478d1153955b4b4cbec7ffe95eb4a47a48499a79c3",
+        strip_prefix = "bazel-lib-2.0.3",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.0.3/bazel-lib-v2.0.3.tar.gz",
+    )
+
     http_archive(
         name = "io_bazel_rules_go",
         sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",

--- a/webpack/dependencies.bzl
+++ b/webpack/dependencies.bzl
@@ -15,16 +15,16 @@ def rules_webpack_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "e3151d87910f69cf1fc88755392d7c878034a69d6499b287bcfc00b1cf9bb415",
-        strip_prefix = "bazel-lib-1.32.1",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.32.1/bazel-lib-v1.32.1.tar.gz",
+        sha256 = "262e3d6693cdc16dd43880785cdae13c64e6a3f63f75b1993c716295093d117f",
+        strip_prefix = "bazel-lib-1.38.1",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.38.1/bazel-lib-v1.38.1.tar.gz",
     )
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "7cb2d84b7d5220194627c9a0267ae599e357350e75ea4f28f337a25ca6219b83",
-        strip_prefix = "rules_js-1.29.2",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v1.29.2/rules_js-v1.29.2.tar.gz",
+        sha256 = "d9ceb89e97bb5ad53b278148e01a77a3e9100db272ce4ebdcd59889d26b9076e",
+        strip_prefix = "rules_js-1.34.0",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.34.0/rules_js-v1.34.0.tar.gz",
     )
 
     http_archive(

--- a/webpack/private/webpack_bundle.bzl
+++ b/webpack/private/webpack_bundle.bzl
@@ -1,7 +1,7 @@
 """Webpack bundle producing rule definition."""
 
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_files_to_bin_actions")
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_files_to_bin_actions")
 load("@aspect_bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
@@ -233,12 +233,14 @@ lib = struct(
     implementation = _impl,
     attrs = _attrs,
     outputs = _outs,
+    toolchains = COPY_FILE_TO_BIN_TOOLCHAINS,
 )
 
 _webpack_bundle = rule(
     implementation = lib.implementation,
     attrs = lib.attrs,
     outputs = lib.outputs,
+    toolchains = lib.toolchains,
     doc = "",
 )
 


### PR DESCRIPTION
Register the "coreutils" toolchains using definitions imported from the _bazel_lib_ Bazel repository in order to allow use of this module with _bazel_lib_ version 2 and later.

---

### Type of change

New feature or functionality (change which adds functionality)

### Test plan

Covered by existing test cases

See aspect-build/rules_esbuild#165 for precedent.

Fixes #134.