### PR TITLE
chore: bump all dependendies to latest

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,2 +1,2 @@
 BAZELISK_BASE_URL=https://github.com/aspect-build/aspect-cli/releases/download
-USE_BAZEL_VERSION=aspect/5.7.2
+USE_BAZEL_VERSION=aspect/5.8.19

--- a/.bazelrc
+++ b/.bazelrc
@@ -2,9 +2,6 @@
 # Take care to document any settings that you expect users to apply.
 # Settings that apply only to CI are in .github/workflows/ci.bazelrc
 
-# for rules_js
-build --enable_runfiles
-
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members
 # This needs to be last statement in this

--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-6.3.2
+6.4.0
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,15 @@ jobs:
         if: matrix.bzlmodEnabled
         run: echo "bzlmod_flag=--enable_bzlmod" >> $GITHUB_OUTPUT
 
+      - name: Don't use Aspect CLI on Windows
+        # TODO: re-enable Aspect CLI on Windows once we have Windows releases
+        if: matrix.os == 'windows-latest'
+        working-directory: ${{ matrix.folder }}
+        run: |
+          if (Test-Path .bazeliskrc) {
+              Remove-Item .bazeliskrc -verbose
+          }
+
       - name: bazel test //...
         env:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
@@ -133,7 +142,8 @@ jobs:
         run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} //...
 
       - name: run ./test.sh
+        # Run if there is a test.sh file in the folder.
+        if: matrix.os != 'windows-latest' && hashFiles(format('{0}/test.sh', matrix.folder)) != ''
         working-directory: ${{ matrix.folder }}
-        # hashFiles returns an empty string if test.sh is absent
-        if: ${{ hashFiles(format('{0}/test.sh', matrix.folder)) != '' }}
+        shell: bash
         run: ./test.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,18 +9,18 @@ default_stages: [commit]
 repos:
   # Check formatting and lint for starlark code
   - repo: https://github.com/keith/pre-commit-buildifier
-    rev: 4.0.1.1
+    rev: 6.4.0
     hooks:
       - id: buildifier
       - id: buildifier-lint
   # Enforce that commit messages allow for later changelog generation
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.18.0
+    rev: v3.13.0
     hooks:
       # Requires that commitizen is already installed
       - id: commitizen
         stages: [commit-msg]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v2.4.0'
+    rev: v3.1.0
     hooks:
       - id: prettier

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,13 +17,19 @@ gazelle(
 )
 
 buildifier(
+    name = "buildifier",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "fix",
+    lint_warnings = ["-out-of-order-load"],  # TODO: enable out-of-order-load
+    mode = "fix",
+)
+
+buildifier(
     name = "buildifier.check",
-    exclude_patterns = [
-        "./.git/*",
-    ],
+    exclude_patterns = ["./.git/*"],
     lint_mode = "warn",
+    lint_warnings = ["-out-of-order-load"],  # TODO: enable out-of-order-load
     mode = "diff",
-    tags = ["manual"],  # tag as manual so windows ci does not build it by default
 )
 
 bzl_library(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,10 +6,11 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.32.0")
-bazel_dep(name = "aspect_rules_js", version = "1.29.2")
-bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.39.1")
+bazel_dep(name = "aspect_rules_js", version = "1.34.1")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
 
-bazel_dep(name = "gazelle", version = "0.29.0", dev_dependency = True, repo_name = "bazel_gazelle")
-bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
-bazel_dep(name = "buildifier_prebuilt", version = "6.1.2.1", dev_dependency = True)
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@ rules_js_dependencies()
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
 
-aspect_bazel_lib_dependencies(override_local_config_platform = True)
+aspect_bazel_lib_dependencies()
 
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
 

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,8 +1,8 @@
 "Bazel dependencies"
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.32.0")
-bazel_dep(name = "aspect_rules_js", version = "1.33.1")
-bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.39.1")
+bazel_dep(name = "aspect_rules_js", version = "1.34.1")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
 
 bazel_dep(name = "aspect_rules_webpack", version = "0.0.0", dev_dependency = True)
 local_path_override(

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -9,35 +9,42 @@ load("//webpack/private:maybe.bzl", http_archive = "maybe_http_archive")
 
 def rules_webpack_internal_deps():
     "Fetch repositories used for developing the rules"
+
+    # opt-in to 2.0 without forcing users to do so
+    http_archive(
+        name = "aspect_bazel_lib",
+        sha256 = "fc8bd670380eaba5314769abbe9fee21d641e3da06d9d26b8073a301f6d62332",
+        strip_prefix = "bazel-lib-2.1.0",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.1.0/bazel-lib-v2.1.0.tar.gz",
+    )
+
     http_archive(
         name = "io_bazel_rules_go",
-        sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
-        urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip"],
+        sha256 = "7c76d6236b28ff695aa28cf35f95de317a9472fd1fb14ac797c9bf684f09b37c",
+        urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.44.2/rules_go-v0.44.2.zip"],
     )
 
     http_archive(
         name = "bazel_gazelle",
-        sha256 = "448e37e0dbf61d6fa8f00aaa12d191745e14f07c31cabfa731f0c8e8a4f41b97",
-        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz"],
+        sha256 = "32938bda16e6700063035479063d9d24c60eda8d79fd4739563f50d331cb3209",
+        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz"],
     )
 
     http_archive(
         name = "bazel_skylib_gazelle_plugin",
-        sha256 = "0a466b61f331585f06ecdbbf2480b9edf70e067a53f261e0596acd573a7d2dc3",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-gazelle-plugin-1.4.1.tar.gz"],
+        sha256 = "747addf3f508186234f6232674dd7786743efb8c68619aece5fb0cac97b8f415",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-gazelle-plugin-1.5.0.tar.gz"],
     )
 
     http_archive(
         name = "io_bazel_stardoc",
-        sha256 = "3fd8fec4ddec3c670bd810904e2e33170bedfe12f90adf943508184be458c8bb",
-        urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz"],
+        sha256 = "62bd2e60216b7a6fec3ac79341aa201e0956477e7c8f6ccc286f279ad1d96432",
+        urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz"],
     )
 
     http_archive(
         name = "buildifier_prebuilt",
-        sha256 = "e46c16180bc49487bfd0f1ffa7345364718c57334fa0b5b67cb5f27eba10f309",
-        strip_prefix = "buildifier-prebuilt-6.1.0",
-        urls = [
-            "https://github.com/keith/buildifier-prebuilt/archive/6.1.0.tar.gz",
-        ],
+        sha256 = "8ada9d88e51ebf5a1fdff37d75ed41d51f5e677cdbeafb0a22dda54747d6e07e",
+        strip_prefix = "buildifier-prebuilt-6.4.0",
+        urls = ["http://github.com/keith/buildifier-prebuilt/archive/6.4.0.tar.gz"],
     )

--- a/webpack/dependencies.bzl
+++ b/webpack/dependencies.bzl
@@ -9,26 +9,26 @@ load("//webpack/private:maybe.bzl", http_archive = "maybe_http_archive")
 def rules_webpack_dependencies():
     http_archive(
         name = "bazel_skylib",
-        sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz"],
+        sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"],
     )
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "e3151d87910f69cf1fc88755392d7c878034a69d6499b287bcfc00b1cf9bb415",
-        strip_prefix = "bazel-lib-1.32.1",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.32.1/bazel-lib-v1.32.1.tar.gz",
+        sha256 = "5e9588d8407a576771f1e0d8956f541f78610f1b6e4cca29af2a096fccfe3b24",
+        strip_prefix = "bazel-lib-1.39.1",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.39.1/bazel-lib-v1.39.1.tar.gz",
     )
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "7cb2d84b7d5220194627c9a0267ae599e357350e75ea4f28f337a25ca6219b83",
-        strip_prefix = "rules_js-1.29.2",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v1.29.2/rules_js-v1.29.2.tar.gz",
+        sha256 = "76a04ef2120ee00231d85d1ff012ede23963733339ad8db81f590791a031f643",
+        strip_prefix = "rules_js-1.34.1",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.34.1/rules_js-v1.34.1.tar.gz",
     )
 
     http_archive(
         name = "rules_nodejs",
-        sha256 = "764a3b3757bb8c3c6a02ba3344731a3d71e558220adcb0cf7e43c9bba2c37ba8",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
+        sha256 = "8fc8e300cb67b89ceebd5b8ba6896ff273c84f6099fc88d23f24e7102319d8fd",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.4/rules_nodejs-core-5.8.4.tar.gz"],
     )


### PR DESCRIPTION
It is much simpler and faster to bump all dependencies to the latest then it is to determine what is the minimal set for Bazel 7 support.

Same as https://github.com/aspect-build/rules_esbuild/pull/174.