### PR TITLE
docs: fix webpack_devserver link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _Need help?_ This ruleset has support provided by https://aspect.dev.
 ## API documentation
 
 - [webpack](https://github.com/aspect-build/rules_webpack/blob/main/docs/rules.md#webpack_bundle)
-- [webpack-dev-server](https://github.com/aspect-build/rules_webpack/blob/main/docs/rules.md#webpack_dev_server)
+- [webpack-devserver](https://github.com/aspect-build/rules_webpack/blob/main/docs/rules.md#webpack_devserver)
 
 ## Installation
 


### PR DESCRIPTION
See broken link at https://docs.aspect.build/rulesets/aspect_rules_webpack#api-documentation