### PR TITLE
Revert "fix: expand make variables properly when passed via args (#140)"

### DIFF
--- a/e2e/smoke/src/BUILD.bazel
+++ b/e2e/smoke/src/BUILD.bazel
@@ -15,21 +15,10 @@ webpack_bundle(
     node_modules = "//v5:node_modules",
 )
 
-# Validates that args are properly expanded when
-# a format string is passed
-entryPointFile = 'entry-point.js'
-webpack_bundle(
-    name = "bundle-entry-args-v5",
-    args = ['--entry', '$(rootpath {})'.format(entryPointFile)],
-    srcs = ["entry-point.js"],
-    node_modules = "//v5:node_modules",
-)
-
 write_source_files(
     name = "bundles",
     files = {
         "expected-v4.js_": ":bundle-v4.js",
         "expected-v5.js_": ":bundle-v5.js",
-        "expected-v5.js_": ":bundle-entry-args-v5.js",
     },
 )

--- a/e2e/smoke/src/entry-point.js
+++ b/e2e/smoke/src/entry-point.js
@@ -1,3 +1,0 @@
-import { version } from './module'
-
-console.log(version)

--- a/webpack/private/webpack_bundle.bzl
+++ b/webpack/private/webpack_bundle.bzl
@@ -121,13 +121,7 @@ def _impl(ctx):
         ])
 
     # Add user specified arguments after rule supplied arguments
-    args.add_all([
-        " ".join([
-            expand_variables(ctx, exp, attribute_name = "args")
-            for exp in expand_locations(ctx, arg, entry_points_srcs + ctx.attr.srcs + ctx.attr.deps + ctx.attr.data).split(" ")
-        ])
-        for arg in ctx.attr.args
-    ])
+    args.add_all(ctx.attr.args)
 
     executable = ctx.executable.webpack_exec_cfg
     execution_requirements = {}


### PR DESCRIPTION
This reverts commit a9621566154a4a6c253337db40656fd2d6eb5398.