### PR TITLE
fix: Use .cjs for generated webpack config

### DIFF
--- a/webpack/private/webpack_create_configs.bzl
+++ b/webpack/private/webpack_create_configs.bzl
@@ -120,7 +120,7 @@ def webpack_create_configs(
     if entry_points_mandatory and not entry_point and not entry_points:
         fail("One of entry_point or entry_points must be specified")
 
-    default_config = "%s.webpack.config.js" % name
+    default_config = "%s.webpack.config.cjs" % name
     _create_base_config(
         name = "_%s_config" % name,
         config_out = default_config,

--- a/webpack/tests/create_configs/BUILD.bazel
+++ b/webpack/tests/create_configs/BUILD.bazel
@@ -65,10 +65,10 @@ webpack_create_configs(
 write_source_files(
     name = "tests",
     files = {
-        "expected.basic.webpack.js": "basic.webpack.config.js",
-        "expected.devtool_mode.webpack.js": "devtool_mode.webpack.config.js",
-        "expected.entry.webpack.js": "entry.webpack.config.js",
-        "expected.entries.webpack.js": "entries.webpack.config.js",
-        "expected.chdir.webpack.js": "chdir.webpack.config.js",
+        "expected.basic.webpack.js": "basic.webpack.config.cjs",
+        "expected.devtool_mode.webpack.js": "devtool_mode.webpack.config.cjs",
+        "expected.entry.webpack.js": "entry.webpack.config.cjs",
+        "expected.entries.webpack.js": "entries.webpack.config.cjs",
+        "expected.chdir.webpack.js": "chdir.webpack.config.cjs",
     },
 )


### PR DESCRIPTION
This makes it compatible with repos which use ESM