### PR TITLE
fix: add homepage URL to metadata template

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,4 +1,5 @@
 {
+  "homepage": "https://docs.aspect.build/bazel/javascript",
   "maintainers": [
     {
       "email": "jason@aspect.build",


### PR DESCRIPTION
it's required by BCR
