### PR TITLE
chore: upgrade rjs3 test to rules_js 3.0.0-rc6

### DIFF
--- a/e2e/smoke_rjs3/MODULE.bazel
+++ b/e2e/smoke_rjs3/MODULE.bazel
@@ -5,7 +5,7 @@ local_path_override(
 )
 
 bazel_dep(name = "bazel_lib", version = "3.1.0", dev_dependency = True)
-bazel_dep(name = "aspect_rules_js", version = "3.0.0-alpha.4", dev_dependency = True)
+bazel_dep(name = "aspect_rules_js", version = "3.0.0-rc6", dev_dependency = True)
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
 npm.npm_translate_lock(


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
