### PR TITLE
test: resolve the failing Windows CI builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
+# Ensure that all text files have Unix-style LF line endings, even on Windows.
+# This way, the Webpack output will be consistent across platforms.
+* text=auto eol=lf
 docs/*_*.md linguist-generated=true
 pnpm-lock.yaml linguist-generated=true

--- a/e2e/worker/BUILD.bazel
+++ b/e2e/worker/BUILD.bazel
@@ -24,11 +24,21 @@ webpack_bundle(
     entry_point = "module.js",
     node_modules = "//:node_modules",
     supports_workers = True,
+    # Setting use_execroot_entry_point = False requires runfiles to be enabled,
+    # so this does not work by default on Windows. Let's tag this "manual" and
+    # disable the test below on Windows.
+    tags = ["manual"],
     use_execroot_entry_point = False,
 )
+
+not_windows = select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})
 
 diff_test(
     name = "bundles_match",
     file1 = "bundle.js",
     file2 = "bundle_no_execroot_entry_point.js",
+    target_compatible_with = not_windows,
 )

--- a/webpack/tests/simple/BUILD.bazel
+++ b/webpack/tests/simple/BUILD.bazel
@@ -54,12 +54,22 @@ webpack_bundle(
         "MY_ENV": "$(execpath :index.js)",
     },
     node_modules = "//:node_modules",
+    # Setting use_execroot_entry_point = False requires runfiles to be enabled,
+    # so this does not work by default on Windows. Let's tag this "manual" and
+    # disable the test below on Windows.
+    tags = ["manual"],
     use_execroot_entry_point = False,
     webpack_config = ":webpack.config.js",
 )
+
+not_windows = select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})
 
 diff_test(
     name = "bundle_no_execroot_entry_point_matches",
     file1 = "bundle.js",
     file2 = "bundle_no_execroot_entry_point.js",
+    target_compatible_with = not_windows,
 )


### PR DESCRIPTION
1. We have a few tests that compare Webpack output with a checked-in golden file. These were failing on Windows because Webpack was outputting CRLF line endings in some cases. Webpack adheres to the line endings of its input files, and Git's default behavior is to normalize text files to have CRLF line endings in Windows checkouts. This change fixes that problem by just configuring Git to always use LF line endings, even on Windows.
2. The `webpack_bundle` targets that use `use_execroot_entry_point = False` are not currently compatible with Windows. You have to either have `use_execroot_entry_point = True` *or* have runfiles enabled, but Windows builds disable runfiles by default. So this change disables the affected targets on Windows.

---

### Changes are visible to end-users: no

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases