### PR TITLE
chore: remove the last references to WORKSPACE support

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -35,6 +35,26 @@ tasks:
     - checkout:
           update_strategy: rebase
     - test:
+          name: 'Test (Bazel 7)'
+          env:
+              USE_BAZEL_VERSION: 7.x
+          bazel:
+              flags:
+                  - --test_tag_filters=-skip-on-bazel7
+    - test:
+          name: 'Test (Bazel 8)'
+          env:
+              USE_BAZEL_VERSION: 8.x
+          bazel:
+              flags:
+                  - --test_tag_filters=-skip-on-bazel8
+    - test:
+          name: 'Test (Bazel 9)'
+          env:
+              USE_BAZEL_VERSION: 9.x
+          bazel:
+              flags:
+                  - --test_tag_filters=-skip-on-bazel9
     - buildifier:
           queue: aspect-medium
     - finalization:

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,8 +1,8 @@
 bcr_test_module:
   module_path: 'e2e/smoke'
   matrix:
-    bazel: ['8.x', '7.x']
-    platform: ['debian10', 'macos', 'ubuntu2004', 'windows']
+    bazel: ['7.x', '8.x', '9.x']
+    platform: ['debian11', 'macos', 'ubuntu2204', 'windows']
   tasks:
     run_tests:
       name: 'Run test module'

--- a/.github/workflows/BUILD.bazel
+++ b/.github/workflows/BUILD.bazel
@@ -2,4 +2,8 @@ load("@bazelrc-preset.bzl", "bazelrc_preset")
 
 bazelrc_preset(
     name = "bazel7",
+    tags = [
+        "skip-on-bazel8",
+        "skip-on-bazel9",
+    ],
 )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,21 +15,23 @@ Otherwise later tooling on CI may yell at you about formatting/linting violation
 
 ## Using this as a development dependency of other rules
 
-You'll commonly find that you develop in another WORKSPACE, such as
+You'll commonly find that you develop in another module, such as
 some other ruleset that depends on rules_webpack, or in a nested
-WORKSPACE in the integration_tests folder.
+module in the `e2e/` folder.
 
-To always tell Bazel to use this directory rather than some release
-artifact or a version fetched from the internet, run this from this
-directory:
+To tell Bazel to use this directory rather than a released artifact
+or a version fetched from the registry, add a `local_path_override` to
+the consumer's `MODULE.bazel`:
 
-```sh
-OVERRIDE="--override_repository=rules_webpack=$(pwd)/rules_webpack"
-echo "build $OVERRIDE" >> ~/.bazelrc
-echo "query $OVERRIDE" >> ~/.bazelrc
+```starlark
+bazel_dep(name = "aspect_rules_webpack", version = "0.0.0")
+local_path_override(
+    module_name = "aspect_rules_webpack",
+    path = "/path/to/aspect_rules_webpack",
+)
 ```
 
-This means that any usage of `@rules_webpack` on your system will point to this folder.
+The `e2e/*/MODULE.bazel` files in this repo demonstrate this pattern.
 
 ## Releasing
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ module(
 # Lower-bounds (minimum) versions for direct runtime dependencies
 bazel_dep(name = "bazel_lib", version = "3.0.0")
 bazel_dep(name = "aspect_rules_js", version = "3.0.3")
-bazel_dep(name = "aspect_tools_telemetry", version = "0.2.8")
+bazel_dep(name = "aspect_tools_telemetry", version = "0.3.3")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 
 tel = use_extension("@aspect_tools_telemetry//:extension.bzl", "telemetry")
@@ -22,7 +22,7 @@ bazel_dep(name = "bazelrc-preset.bzl", version = "1.5.1", dev_dependency = True)
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
 bazel_dep(name = "gazelle", version = "0.36.0", dev_dependency = True, repo_name = "bazel_gazelle")
-bazel_dep(name = "platforms", version = "0.0.8", dev_dependency = True)
+bazel_dep(name = "platforms", version = "1.0.0", dev_dependency = True)
 
 buildifier_prebuilt = use_extension(
     "@buildifier_prebuilt//:defs.bzl",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
 bazel_dep(name = "bazelrc-preset.bzl", version = "1.5.1", dev_dependency = True)
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
-bazel_dep(name = "gazelle", version = "0.36.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "gazelle", version = "0.50.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "platforms", version = "1.0.0", dev_dependency = True)
 
 buildifier_prebuilt = use_extension(

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ _Need help?_ This ruleset has support provided by https://aspect.build/services.
 
 ## Installation
 
-From the release you wish to use:
-<https://github.com/aspect-build/rules_webpack/releases>
-copy the WORKSPACE snippet into your `WORKSPACE` file.
+Add to your `MODULE.bazel`:
+
+```starlark
+bazel_dep(name = "aspect_rules_webpack", version = "x.y.z")
+```
+
+See the [Bazel Central
+Registry](https://registry.bazel.build/modules/aspect_rules_webpack) for the latest
+version and the full setup snippet.

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -7,4 +7,10 @@ stardoc_with_diff_test(
     bzl_library_target = "//webpack:defs",
 )
 
-update_docs(name = "update")
+update_docs(
+    name = "update",
+    tags = [
+        "skip-on-bazel8",
+        "skip-on-bazel9",
+    ],
+)

--- a/e2e/worker/MODULE.bazel
+++ b/e2e/worker/MODULE.bazel
@@ -6,6 +6,7 @@ local_path_override(
 
 bazel_dep(name = "bazel_lib", version = "3.0.0", dev_dependency = True)
 bazel_dep(name = "aspect_rules_js", version = "3.0.3", dev_dependency = True)
+bazel_dep(name = "platforms", version = "1.0.0", dev_dependency = True)
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
 npm.npm_translate_lock(

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -5,5 +5,6 @@ bazelrc_preset(
     # The output is specific to the version in .bazelversion
     tags = [
         "skip-on-bazel8",
+        "skip-on-bazel9",
     ],
 )

--- a/webpack/BUILD.bazel
+++ b/webpack/BUILD.bazel
@@ -9,6 +9,5 @@ bzl_library(
     deps = [
         "//webpack/private:webpack_bundle",
         "//webpack/private:webpack_devserver",
-        "@bazel_tools//tools/build_defs/repo:cache.bzl",
     ],
 )

--- a/webpack/private/maybe.bzl
+++ b/webpack/private/maybe.bzl
@@ -1,7 +1,0 @@
-"maybe utilities"
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-
-def maybe_http_archive(**kwargs):
-    maybe(_http_archive, **kwargs)


### PR DESCRIPTION
This change also updates our CI configs to ensure we're testing Bazel 7 through 9 and on modern platforms.

Close #165

### Changes are visible to end-users: no

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases