### PR TITLE
refactor: simplify webpack_worker.js given single worker per executable

### DIFF
--- a/webpack/private/webpack_worker.js
+++ b/webpack/private/webpack_worker.js
@@ -19,9 +19,6 @@ class WebpackWorker extends WebpackCLI {
   /** @type {import("@bazel/worker").Inputs | null} */
   previousInputs = null
 
-  /** @type {{[k: string]: unknown} | null} */
-  options = null
-
   /** @type {Function | null} */
   resolve = null
   /** @type {Function | null} */
@@ -70,27 +67,16 @@ class WebpackWorker extends WebpackCLI {
       )
     }
     this.compiler = null
-    this.options = null
     this.previousInputs = null
   }
 
   async createCompiler(options) {
-    if (
-      this.options != null &&
-      JSON.stringify(options) != JSON.stringify(this.options)
-    ) {
-      console.error(
-        `[${MNEMONIC}] options have changed. discarding webpack cache.`
-      )
-      await this.teardown()
-    }
     const cb = (err, stats) => this.callback(err, stats)
     if (this.compiler) {
       this.compiler.run(cb)
     } else {
       console.error(options)
       this.compiler = await super.createCompiler(options, cb)
-      this.options = options
 
       // The output directory will be cleaned between runs, however webpack assumes the
       // output directory will not be modified and caches the file system state.
@@ -134,17 +120,7 @@ class WebpackWorker extends WebpackCLI {
   }
 }
 
-/** @type {Map<string, WebpackWorker>} */
-const workers = new Map()
-
-function createOrGetWorker(args) {
-  const key = args[args.indexOf('--config') + 1]
-  if (!workers.has(key)) {
-    console.error(`New ${MNEMONIC} worker for ${key}`)
-    workers.set(key, new WebpackWorker())
-  }
-  return workers.get(key)
-}
+const worker = new WebpackWorker()
 
 async function emit(request) {
   const inputs = Object.fromEntries(
@@ -155,7 +131,6 @@ async function emit(request) {
         : null,
     ])
   )
-  const worker = createOrGetWorker(request.arguments)
   const previousInputs = worker.previousInputs
   const bazelBin = process.cwd()
   const execRoot = path.resolve(bazelBin, '..', '..', '..')


### PR DESCRIPTION
Each webpack_bundle() target with workers gets its own dedicated binary, so a single worker process always handles one config. Replace the workers Map (keyed by config path) with a single module-level WebpackWorker instance, and remove the dead options-change detection in createCompiler (JSON.stringify comparison that could never fire) along with the options field that only existed to support it.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases