### PR TITLE
fix: build configs for the exec platform when use_execroot_entry_point = False

### DIFF
--- a/e2e/loaders/BUILD.bazel
+++ b/e2e/loaders/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_js//js:defs.bzl", "js_run_devserver")
+load("@aspect_rules_js//js:defs.bzl", "js_library", "js_run_devserver")
 load("@aspect_rules_webpack//webpack:defs.bzl", "webpack_bundle")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
@@ -10,6 +10,31 @@ http_server_bin.http_server_binary(
 
 npm_link_all_packages(name = "node_modules")
 
+js_library(
+    name = "webpack-css-config",
+    srcs = ["webpack.css.cjs"],
+    deps = [
+        ":node_modules/css-loader",
+        ":node_modules/mini-css-extract-plugin",
+    ],
+)
+
+js_library(
+    name = "webpack-ts-config",
+    srcs = ["webpack.config.cjs"],
+    deps = [":node_modules/ts-loader"],
+)
+
+js_library(
+    name = "webpack-html-config",
+    srcs = ["webpack.html.cjs"],
+    deps = [
+        ":node_modules/css-loader",
+        ":node_modules/html-webpack-plugin",
+        ":node_modules/mini-css-extract-plugin",
+    ],
+)
+
 webpack_bundle(
     name = "css",
     srcs = [
@@ -18,11 +43,7 @@ webpack_bundle(
     ],
     node_modules = "//:node_modules",
     output_dir = True,
-    webpack_config = ":webpack.css.cjs",
-    deps = [
-        ":node_modules/css-loader",
-        ":node_modules/mini-css-extract-plugin",
-    ],
+    webpack_config = ":webpack-css-config",
 )
 
 webpack_bundle(
@@ -33,11 +54,7 @@ webpack_bundle(
     ],
     node_modules = "//:node_modules",
     output_dir = True,
-    webpack_config = ":webpack.css.cjs",
-    deps = [
-        ":node_modules/css-loader",
-        ":node_modules/mini-css-extract-plugin",
-    ],
+    webpack_config = ":webpack-css-config",
 )
 
 webpack_bundle(
@@ -48,10 +65,7 @@ webpack_bundle(
     ],
     node_modules = "//:node_modules",
     output_dir = True,
-    webpack_config = ":webpack.config.cjs",
-    deps = [
-        ":node_modules/ts-loader",
-    ],
+    webpack_config = ":webpack-ts-config",
 )
 
 webpack_bundle(
@@ -62,10 +76,7 @@ webpack_bundle(
     ],
     node_modules = "//:node_modules",
     output_dir = True,
-    webpack_config = ":webpack.config.cjs",
-    deps = [
-        ":node_modules/ts-loader",
-    ],
+    webpack_config = ":webpack-ts-config",
 )
 
 # supports_worker + js_run_devserver
@@ -79,12 +90,7 @@ webpack_bundle(
     node_modules = "//:node_modules",
     output_dir = True,
     supports_workers = True,  # Required to reproduce https://github.com/aspect-build/rules_webpack/issues/126
-    webpack_config = ":webpack.html.cjs",
-    deps = [
-        ":node_modules/css-loader",
-        ":node_modules/html-webpack-plugin",
-        ":node_modules/mini-css-extract-plugin",
-    ],
+    webpack_config = ":webpack-html-config",
 )
 
 # Use a js_run_devserver to reproduce https://github.com/aspect-build/rules_webpack/issues/126

--- a/e2e/loaders/webpack.config.cjs
+++ b/e2e/loaders/webpack.config.cjs
@@ -3,10 +3,10 @@ const path = require("path");
 module.exports = (_env, options) => {
     return {
         entry: {
-            index: path.resolve(__dirname, "src/index.ts"),
+            index: path.resolve(process.cwd(), "src/index.ts"),
         },
         output: {
-            path: path.resolve(__dirname, "dist"),
+            path: path.resolve(process.cwd(), "dist"),
             filename: "[name].bundle.js",
 
             // Alternative and webpack5 default:

--- a/e2e/loaders/webpack.css.cjs
+++ b/e2e/loaders/webpack.css.cjs
@@ -4,10 +4,10 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 module.exports = (_env, options) => {
     return {
         entry: {
-            styles: path.resolve(__dirname, "src/component.js")
+            styles: path.resolve(process.cwd(), "src/component.js")
         },
         output: {
-            path: path.resolve(__dirname, "dist"),
+            path: path.resolve(process.cwd(), "dist"),
             filename: "[name].bundle.js"
         },
         plugins: [

--- a/e2e/loaders/webpack.html.cjs
+++ b/e2e/loaders/webpack.html.cjs
@@ -5,16 +5,16 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 module.exports = (_env, options) => {
   return {
     entry: {
-      styles: path.resolve(__dirname, 'src/component.js'),
+      styles: path.resolve(process.cwd(), 'src/component.js'),
     },
     output: {
-      path: path.resolve(__dirname, 'dist'),
+      path: path.resolve(process.cwd(), 'dist'),
       filename: '[name].bundle.js',
     },
     plugins: [
       new MiniCssExtractPlugin(),
       new HtmlWebpackPlugin({
-        template: path.resolve(__dirname + '/src/index.html'),
+        template: path.resolve(process.cwd() + '/src/index.html'),
       }),
     ],
     module: {

--- a/e2e/loaders_jslib/webpack.config.cjs
+++ b/e2e/loaders_jslib/webpack.config.cjs
@@ -3,10 +3,10 @@ const path = require("path");
 module.exports = (_env, options) => {
     return {
         entry: {
-            index: path.resolve(__dirname, "src/index.ts"),
+            index: path.resolve(process.cwd(), "src/index.ts"),
         },
         output: {
-            path: path.resolve(__dirname, "dist"),
+            path: path.resolve(process.cwd(), "dist"),
             filename: "[name].bundle.js",
 
             // Alternative and webpack5 default:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,12 +32,155 @@ importers:
       sass-loader:
         specifier: 16.0.8
         version: 16.0.8(sass@1.99.0)(webpack@5.106.2(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.106.2)))
+      sharp:
+        specifier: 0.34.5
+        version: 0.34.5
 
 packages:
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1362,6 +1505,11 @@ packages:
     resolution: {integrity: sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==}
     engines: {node: '>=18'}
 
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.2:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
@@ -1383,6 +1531,10 @@ packages:
   shallow-clone@3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1683,6 +1835,107 @@ packages:
 snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2406,8 +2659,7 @@ snapshots:
 
   destroy@1.2.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-node@2.1.0: {}
 
@@ -3063,6 +3315,8 @@ snapshots:
       '@peculiar/x509': 1.14.3
       pkijs: 3.4.0
 
+  semver@7.8.1: {}
+
   send@0.19.2:
     dependencies:
       debug: 2.6.9
@@ -3109,6 +3363,37 @@ snapshots:
   shallow-clone@3.0.1:
     dependencies:
       kind-of: 6.0.3
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.1
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:

--- a/webpack/private/webpack.config.js.tmpl
+++ b/webpack/private/webpack.config.js.tmpl
@@ -29,10 +29,9 @@ module.exports = function () {
     uniqueName: process.env.BAZEL_WORKSPACE,
   }
 
-  // When the config is loaded from runfiles, __dirname is the runfiles package
-  // directory which has node_modules symlinks from npm_link_all_packages.
-  // Adding it to resolveLoader.modules lets webpack find loaders declared as
-  // deps of the webpack config js_library.
+  // When use_execroot_entry_point is False, the config files and their dependencies will live in
+  // the runfiles directory. Let's add __dirname to the search path to ensure that we can correctly
+  // resolve loaders from there.
   const resolveLoader = {
     modules: [path.join(__dirname, 'node_modules'), 'node_modules'],
   }

--- a/webpack/private/webpack.config.js.tmpl
+++ b/webpack/private/webpack.config.js.tmpl
@@ -1,3 +1,5 @@
+const path = require('path')
+
 module.exports = function () {
   const v4 = new Error().stack.includes('webpack-cli@4.')
 
@@ -27,6 +29,14 @@ module.exports = function () {
     uniqueName: process.env.BAZEL_WORKSPACE,
   }
 
+  // When the config is loaded from runfiles, __dirname is the runfiles package
+  // directory which has node_modules symlinks from npm_link_all_packages.
+  // Adding it to resolveLoader.modules lets webpack find loaders declared as
+  // deps of the webpack config js_library.
+  const resolveLoader = {
+    modules: [path.join(__dirname, 'node_modules'), 'node_modules'],
+  }
+
   // Set by the Bazel rule at action execution time so that the target
   // platform's compilation mode is reflected.
   const mode = process.env.WEBPACK_MODE
@@ -36,6 +46,7 @@ module.exports = function () {
     infrastructureLogging,
     optimization,
     output,
+    resolveLoader,
     ...(mode ? {mode} : {}),
     ...(devtool ? {devtool} : {}),{{ENTRIES}}
   }

--- a/webpack/private/webpack_binary.bzl
+++ b/webpack/private/webpack_binary.bzl
@@ -6,7 +6,9 @@ load("@bazel_lib//lib:directory_path.bzl", "directory_path")
 def webpack_binary(
         name,
         node_modules,
-        additional_packages):
+        additional_packages,
+        additional_data = [],
+        fixed_args = []):
     """Create a webpack binary target from linked node_modules in the user's workspace.
 
     Requires that `webpack` and any additional packages specified are linked into the supplied node_modules tree.
@@ -15,6 +17,8 @@ def webpack_binary(
         name: Unique name for the binary target
         node_modules: Label pointing to the linked node_modules tree where webpack is linked, e.g. `//:node_modules`.
         additional_packages: list of additional packages required. For example ["webpack-cli", "webpack-dev-server"]
+        additional_data: additional data for the binary
+        fixed_args: arguments that will be baked into the binary
     """
 
     directory_path(
@@ -29,7 +33,8 @@ def webpack_binary(
 
     js_binary(
         name = name,
-        data = data,
+        data = data + additional_data,
         entry_point = ":{}_entrypoint".format(name),
+        fixed_args = fixed_args,
         visibility = ["//visibility:public"],
     )

--- a/webpack/private/webpack_binary.bzl
+++ b/webpack/private/webpack_binary.bzl
@@ -7,7 +7,7 @@ def webpack_binary(
         name,
         node_modules,
         additional_packages,
-        additional_data = [],
+        data = [],
         fixed_args = []):
     """Create a webpack binary target from linked node_modules in the user's workspace.
 
@@ -17,7 +17,7 @@ def webpack_binary(
         name: Unique name for the binary target
         node_modules: Label pointing to the linked node_modules tree where webpack is linked, e.g. `//:node_modules`.
         additional_packages: list of additional packages required. For example ["webpack-cli", "webpack-dev-server"]
-        additional_data: additional data for the binary
+        data: data dependencies for the binary
         fixed_args: arguments that will be baked into the binary
     """
 
@@ -27,13 +27,13 @@ def webpack_binary(
         path = "bin/webpack.js",
     )
 
-    data = ["{}/webpack".format(node_modules)]
+    packages = ["{}/webpack".format(node_modules)]
     for p in additional_packages:
-        data.append("{}/{}".format(node_modules, p))
+        packages.append("{}/{}".format(node_modules, p))
 
     js_binary(
         name = name,
-        data = data + additional_data,
+        data = data + packages,
         entry_point = ":{}_entrypoint".format(name),
         fixed_args = fixed_args,
         visibility = ["//visibility:public"],

--- a/webpack/private/webpack_bundle.bzl
+++ b/webpack/private/webpack_bundle.bzl
@@ -392,7 +392,7 @@ def webpack_bundle(
         name = webpack_binary_target,
         node_modules = node_modules,
         additional_packages = ["webpack-cli"],
-        additional_data = [] if use_execroot_entry_point else webpack_configs,
+        data = [] if use_execroot_entry_point else webpack_configs,
         fixed_args = binary_args,
     )
 

--- a/webpack/private/webpack_bundle.bzl
+++ b/webpack/private/webpack_bundle.bzl
@@ -378,11 +378,10 @@ def webpack_bundle(
         entry_points_mandatory = not output_dir,
     )
 
-    # When use_execroot_entry_point is False, we include the configs in the
-    # Webpack binary itself and bake in the associated command-line arguments.
-    # Otherwise, we pass the configs to the underlying _webpack_bundle rule and
+    # When use_execroot_entry_point is False, we use Webpack configs in the
+    # runfiles, which requires baking the command-line arguments into the
+    # binary. Otherwise, we pass the configs to the _webpack_bundle rule and
     # let it handle them.
-    configs_for_binary = [] if use_execroot_entry_point else webpack_configs
     configs_for_webpack_bundle_rule = webpack_configs if use_execroot_entry_point else []
     binary_args = []
     if not use_execroot_entry_point:
@@ -396,7 +395,7 @@ def webpack_bundle(
         name = webpack_binary_target,
         node_modules = node_modules,
         additional_packages = ["webpack-cli"],
-        data = configs_for_binary,
+        data = webpack_configs,
         fixed_args = binary_args,
     )
 
@@ -415,7 +414,7 @@ def webpack_bundle(
                 "{}/webpack-cli".format(node_modules),
                 "{}/webpack-dev-server".format(node_modules),
                 "@aspect_rules_js//js/private/worker:worker.js",
-            ] + configs_for_binary,
+            ] + webpack_configs,
             copy_data_to_bin = False,
             entry_point = "_{}_webpack_worker.js".format(name),
             fixed_args = binary_args,

--- a/webpack/private/webpack_bundle.bzl
+++ b/webpack/private/webpack_bundle.bzl
@@ -143,10 +143,9 @@ def _impl(ctx):
         executable = ctx.executable.webpack_worker_exec_cfg
         execution_requirements["supports-workers"] = str(int(ctx.attr.supports_workers))
 
-        no_copy_bin_inputs.append(ctx.file._worker_js)
-
         path_to_execroot = ("/".join([".."] * len(ctx.label.package.split("/"))) if ctx.label.package else ".") + "/"
         if ctx.attr.use_execroot_entry_point:
+            no_copy_bin_inputs.append(ctx.file._worker_js)
             env["JS_BINARY__ALLOW_EXECROOT_ENTRY_POINT_WITH_NO_COPY_DATA_TO_BIN"] = "1"
             env["RULES_JS_WORKER"] = path_to_execroot + "../../../" + ctx.file._worker_js.path
         else:
@@ -370,14 +369,6 @@ def webpack_bundle(
         **kwargs: Additional arguments
     """
 
-    webpack_binary_target = "_{}_webpack_binary".format(name)
-
-    webpack_binary(
-        name = webpack_binary_target,
-        node_modules = node_modules,
-        additional_packages = ["webpack-cli"],
-    )
-
     webpack_configs = webpack_create_configs(
         name = name,
         entry_point = entry_point,
@@ -385,6 +376,24 @@ def webpack_bundle(
         webpack_config = webpack_config,
         chdir = chdir,
         entry_points_mandatory = not output_dir,
+    )
+
+    # When use_execroot_entry_point is False, we include the configs in the
+    # Webpack binary itself and bake in the associated command-line arguments.
+    binary_args = []
+    if not use_execroot_entry_point:
+        for config in webpack_configs:
+            binary_args.extend(["--config", "$$RUNFILES_DIR/$(rlocationpath %s)" % config])
+        if len(webpack_configs) > 1:
+            binary_args.append("--merge")
+
+    webpack_binary_target = "_{}_webpack_binary".format(name)
+    webpack_binary(
+        name = webpack_binary_target,
+        node_modules = node_modules,
+        additional_packages = ["webpack-cli"],
+        additional_data = [] if use_execroot_entry_point else webpack_configs,
+        fixed_args = binary_args,
     )
 
     webpack_worker_binary_target = None
@@ -402,15 +411,16 @@ def webpack_bundle(
                 "{}/webpack-cli".format(node_modules),
                 "{}/webpack-dev-server".format(node_modules),
                 "@aspect_rules_js//js/private/worker:worker.js",
-            ],
+            ] + ([] if use_execroot_entry_point else webpack_configs),
             copy_data_to_bin = False,
             entry_point = "_{}_webpack_worker.js".format(name),
+            fixed_args = binary_args,
             visibility = ["//visibility:public"],
         )
 
     _webpack_bundle(
         name = name,
-        webpack_configs = webpack_configs,
+        webpack_configs = webpack_configs if use_execroot_entry_point else [],
         srcs = srcs,
         args = args,
         deps = deps,

--- a/webpack/private/webpack_bundle.bzl
+++ b/webpack/private/webpack_bundle.bzl
@@ -380,6 +380,10 @@ def webpack_bundle(
 
     # When use_execroot_entry_point is False, we include the configs in the
     # Webpack binary itself and bake in the associated command-line arguments.
+    # Otherwise, we pass the configs to the underlying _webpack_bundle rule and
+    # let it handle them.
+    configs_for_binary = [] if use_execroot_entry_point else webpack_configs
+    configs_for_webpack_bundle_rule = webpack_configs if use_execroot_entry_point else []
     binary_args = []
     if not use_execroot_entry_point:
         for config in webpack_configs:
@@ -392,7 +396,7 @@ def webpack_bundle(
         name = webpack_binary_target,
         node_modules = node_modules,
         additional_packages = ["webpack-cli"],
-        data = [] if use_execroot_entry_point else webpack_configs,
+        data = configs_for_binary,
         fixed_args = binary_args,
     )
 
@@ -411,7 +415,7 @@ def webpack_bundle(
                 "{}/webpack-cli".format(node_modules),
                 "{}/webpack-dev-server".format(node_modules),
                 "@aspect_rules_js//js/private/worker:worker.js",
-            ] + ([] if use_execroot_entry_point else webpack_configs),
+            ] + configs_for_binary,
             copy_data_to_bin = False,
             entry_point = "_{}_webpack_worker.js".format(name),
             fixed_args = binary_args,
@@ -420,7 +424,7 @@ def webpack_bundle(
 
     _webpack_bundle(
         name = name,
-        webpack_configs = webpack_configs if use_execroot_entry_point else [],
+        webpack_configs = configs_for_webpack_bundle_rule,
         srcs = srcs,
         args = args,
         deps = deps,

--- a/webpack/private/webpack_worker.js
+++ b/webpack/private/webpack_worker.js
@@ -13,6 +13,14 @@ const path = require('path')
 const WebpackCLI = require('webpack-cli')
 const MNEMONIC = 'Webpack'
 
+// Fixed args baked in via js_binary fixed_args (e.g. --config, --merge).
+// In worker mode:     process.argv = [node, script, ...fixed_args, --persistent_worker]
+// In non-worker mode: process.argv = [node, script, ...fixed_args, @params_file]
+// Strip the Bazel-added trailing arg so only the webpack args remain.
+const FIXED_ARGS = process.argv
+  .slice(2)
+  .filter(arg => arg !== '--persistent_worker' && !arg.startsWith('@'))
+
 class WebpackWorker extends WebpackCLI {
   /** @type {import("webpack").Compiler | null} */
   compiler = null
@@ -231,7 +239,7 @@ async function emit(request) {
 
     worker.resolve = resolve
     worker.reject = reject
-    worker.run([process.argv[0], process.argv[1], ...request.arguments])
+    worker.run([process.argv[0], process.argv[1], ...FIXED_ARGS, ...request.arguments])
   })
 }
 
@@ -250,7 +258,7 @@ function emitOnce() {
       --strategy=${MNEMONIC}=worker`
   )
   const args = getArgsFromParamFile()
-  new WebpackCLI().run([process.argv[0], process.argv[1], ...args])
+  new WebpackCLI().run([process.argv[0], process.argv[1], ...FIXED_ARGS, ...args])
 }
 
 function main() {

--- a/webpack/tests/create_configs/expected.basic.webpack.js
+++ b/webpack/tests/create_configs/expected.basic.webpack.js
@@ -29,10 +29,9 @@ module.exports = function () {
     uniqueName: process.env.BAZEL_WORKSPACE,
   }
 
-  // When the config is loaded from runfiles, __dirname is the runfiles package
-  // directory which has node_modules symlinks from npm_link_all_packages.
-  // Adding it to resolveLoader.modules lets webpack find loaders declared as
-  // deps of the webpack config js_library.
+  // When use_execroot_entry_point is False, the config files and their dependencies will live in
+  // the runfiles directory. Let's add __dirname to the search path to ensure that we can correctly
+  // resolve loaders from there.
   const resolveLoader = {
     modules: [path.join(__dirname, 'node_modules'), 'node_modules'],
   }

--- a/webpack/tests/create_configs/expected.basic.webpack.js
+++ b/webpack/tests/create_configs/expected.basic.webpack.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 module.exports = function () {
   const v4 = new Error().stack.includes('webpack-cli@4.')
 
@@ -27,6 +29,14 @@ module.exports = function () {
     uniqueName: process.env.BAZEL_WORKSPACE,
   }
 
+  // When the config is loaded from runfiles, __dirname is the runfiles package
+  // directory which has node_modules symlinks from npm_link_all_packages.
+  // Adding it to resolveLoader.modules lets webpack find loaders declared as
+  // deps of the webpack config js_library.
+  const resolveLoader = {
+    modules: [path.join(__dirname, 'node_modules'), 'node_modules'],
+  }
+
   // Set by the Bazel rule at action execution time so that the target
   // platform's compilation mode is reflected.
   const mode = process.env.WEBPACK_MODE
@@ -36,6 +46,7 @@ module.exports = function () {
     infrastructureLogging,
     optimization,
     output,
+    resolveLoader,
     ...(mode ? {mode} : {}),
     ...(devtool ? {devtool} : {}),
   }

--- a/webpack/tests/create_configs/expected.chdir.webpack.js
+++ b/webpack/tests/create_configs/expected.chdir.webpack.js
@@ -29,10 +29,9 @@ module.exports = function () {
     uniqueName: process.env.BAZEL_WORKSPACE,
   }
 
-  // When the config is loaded from runfiles, __dirname is the runfiles package
-  // directory which has node_modules symlinks from npm_link_all_packages.
-  // Adding it to resolveLoader.modules lets webpack find loaders declared as
-  // deps of the webpack config js_library.
+  // When use_execroot_entry_point is False, the config files and their dependencies will live in
+  // the runfiles directory. Let's add __dirname to the search path to ensure that we can correctly
+  // resolve loaders from there.
   const resolveLoader = {
     modules: [path.join(__dirname, 'node_modules'), 'node_modules'],
   }

--- a/webpack/tests/create_configs/expected.chdir.webpack.js
+++ b/webpack/tests/create_configs/expected.chdir.webpack.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 module.exports = function () {
   const v4 = new Error().stack.includes('webpack-cli@4.')
 
@@ -27,6 +29,14 @@ module.exports = function () {
     uniqueName: process.env.BAZEL_WORKSPACE,
   }
 
+  // When the config is loaded from runfiles, __dirname is the runfiles package
+  // directory which has node_modules symlinks from npm_link_all_packages.
+  // Adding it to resolveLoader.modules lets webpack find loaders declared as
+  // deps of the webpack config js_library.
+  const resolveLoader = {
+    modules: [path.join(__dirname, 'node_modules'), 'node_modules'],
+  }
+
   // Set by the Bazel rule at action execution time so that the target
   // platform's compilation mode is reflected.
   const mode = process.env.WEBPACK_MODE
@@ -36,6 +46,7 @@ module.exports = function () {
     infrastructureLogging,
     optimization,
     output,
+    resolveLoader,
     ...(mode ? {mode} : {}),
     ...(devtool ? {devtool} : {}),
     entry: {"bar.js":"./bar","foo.js":"./foo"},

--- a/webpack/tests/create_configs/expected.entries.webpack.js
+++ b/webpack/tests/create_configs/expected.entries.webpack.js
@@ -29,10 +29,9 @@ module.exports = function () {
     uniqueName: process.env.BAZEL_WORKSPACE,
   }
 
-  // When the config is loaded from runfiles, __dirname is the runfiles package
-  // directory which has node_modules symlinks from npm_link_all_packages.
-  // Adding it to resolveLoader.modules lets webpack find loaders declared as
-  // deps of the webpack config js_library.
+  // When use_execroot_entry_point is False, the config files and their dependencies will live in
+  // the runfiles directory. Let's add __dirname to the search path to ensure that we can correctly
+  // resolve loaders from there.
   const resolveLoader = {
     modules: [path.join(__dirname, 'node_modules'), 'node_modules'],
   }

--- a/webpack/tests/create_configs/expected.entries.webpack.js
+++ b/webpack/tests/create_configs/expected.entries.webpack.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 module.exports = function () {
   const v4 = new Error().stack.includes('webpack-cli@4.')
 
@@ -27,6 +29,14 @@ module.exports = function () {
     uniqueName: process.env.BAZEL_WORKSPACE,
   }
 
+  // When the config is loaded from runfiles, __dirname is the runfiles package
+  // directory which has node_modules symlinks from npm_link_all_packages.
+  // Adding it to resolveLoader.modules lets webpack find loaders declared as
+  // deps of the webpack config js_library.
+  const resolveLoader = {
+    modules: [path.join(__dirname, 'node_modules'), 'node_modules'],
+  }
+
   // Set by the Bazel rule at action execution time so that the target
   // platform's compilation mode is reflected.
   const mode = process.env.WEBPACK_MODE
@@ -36,6 +46,7 @@ module.exports = function () {
     infrastructureLogging,
     optimization,
     output,
+    resolveLoader,
     ...(mode ? {mode} : {}),
     ...(devtool ? {devtool} : {}),
     entry: {"bar.js":"./webpack/tests/create_configs/bar","foo.js":"./webpack/tests/create_configs/foo"},

--- a/webpack/tests/create_configs/expected.entry.webpack.js
+++ b/webpack/tests/create_configs/expected.entry.webpack.js
@@ -29,10 +29,9 @@ module.exports = function () {
     uniqueName: process.env.BAZEL_WORKSPACE,
   }
 
-  // When the config is loaded from runfiles, __dirname is the runfiles package
-  // directory which has node_modules symlinks from npm_link_all_packages.
-  // Adding it to resolveLoader.modules lets webpack find loaders declared as
-  // deps of the webpack config js_library.
+  // When use_execroot_entry_point is False, the config files and their dependencies will live in
+  // the runfiles directory. Let's add __dirname to the search path to ensure that we can correctly
+  // resolve loaders from there.
   const resolveLoader = {
     modules: [path.join(__dirname, 'node_modules'), 'node_modules'],
   }

--- a/webpack/tests/create_configs/expected.entry.webpack.js
+++ b/webpack/tests/create_configs/expected.entry.webpack.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 module.exports = function () {
   const v4 = new Error().stack.includes('webpack-cli@4.')
 
@@ -27,6 +29,14 @@ module.exports = function () {
     uniqueName: process.env.BAZEL_WORKSPACE,
   }
 
+  // When the config is loaded from runfiles, __dirname is the runfiles package
+  // directory which has node_modules symlinks from npm_link_all_packages.
+  // Adding it to resolveLoader.modules lets webpack find loaders declared as
+  // deps of the webpack config js_library.
+  const resolveLoader = {
+    modules: [path.join(__dirname, 'node_modules'), 'node_modules'],
+  }
+
   // Set by the Bazel rule at action execution time so that the target
   // platform's compilation mode is reflected.
   const mode = process.env.WEBPACK_MODE
@@ -36,6 +46,7 @@ module.exports = function () {
     infrastructureLogging,
     optimization,
     output,
+    resolveLoader,
     ...(mode ? {mode} : {}),
     ...(devtool ? {devtool} : {}),
     entry: {"entry":"./webpack/tests/create_configs/entry.js"},

--- a/webpack/tests/cross-platform/BUILD.bazel
+++ b/webpack/tests/cross-platform/BUILD.bazel
@@ -1,0 +1,59 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//webpack:defs.bzl", "webpack_bundle")
+
+# Verify that webpack_bundle builds correctly when the target platform differs
+# from the exec platform. For this to work, we need to set
+# use_execroot_entry_point = False. Otherwise, webpack_bundle will build the
+# Webpack binary and configs for the target platform.
+
+js_library(
+    name = "webpack_config",
+    srcs = ["webpack.config.js"],
+    deps = ["//webpack/tests:node_modules/sharp"],
+)
+
+webpack_bundle(
+    name = "bundle",
+    entry_point = "index.js",
+    node_modules = "//:node_modules",
+    use_execroot_entry_point = False,
+    webpack_config = ":webpack_config",
+)
+
+platform(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "macos_arm64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+platform_transition_filegroup(
+    name = "bundle_targeting_linux",
+    srcs = [":bundle"],
+    target_platform = ":linux_x86_64",
+)
+
+platform_transition_filegroup(
+    name = "bundle_targeting_macos",
+    srcs = [":bundle"],
+    target_platform = ":macos_arm64",
+)
+
+build_test(
+    name = "test",
+    targets = [
+        ":bundle_targeting_linux",
+        ":bundle_targeting_macos",
+    ],
+)

--- a/webpack/tests/cross-platform/index.js
+++ b/webpack/tests/cross-platform/index.js
@@ -1,0 +1,1 @@
+console.log('hello')

--- a/webpack/tests/cross-platform/webpack.config.js
+++ b/webpack/tests/cross-platform/webpack.config.js
@@ -1,0 +1,5 @@
+// Requiring sharp exercises its native C/C++ addon. If the package was resolved
+// for the wrong platform, this will fail when webpack evaluates the config.
+require('sharp')
+
+module.exports = {}

--- a/webpack/tests/package.json
+++ b/webpack/tests/package.json
@@ -3,7 +3,8 @@
     "html-webpack-plugin": "5.6.7",
     "js-yaml": "4.1.1",
     "sass-loader": "16.0.8",
-    "sass": "1.99.0"
+    "sass": "1.99.0",
+    "sharp": "0.34.5"
   },
   "pnpm": {
     "onlyBuiltDependencies": []


### PR DESCRIPTION
Since Webpack configs are written in JavaScript and executed during the build, they should be built for the exec platform. This change ensures that happens by making the config files dependencies of the Weback binary in the `webpack_bundle()` macro.

This required a few fixes:
 - Configs with dependencies needed to be grouped into `js_library` targets.
 - Some configs needed to start referencing `process.cwd()` instead of `__dirname`, since `__dirname` now refers to a different directory when the config file is in the runfiles directory.
 - Similarly, `resolveLoader` has to be set in the generated based config to search in the current directory.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes, but not likely to be disruptive since `use_execroot_entry_point` is `True` by default
- Suggested release notes appear below: yes

Webpack configs are now built for the exec platform when `use_execroot_entry_point` is `False`.

### Test plan

- Covered by existing test cases
- New test cases added
